### PR TITLE
RHMAP-19582

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright © 2014-2018 Andrew Chilton <andychilton@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a 
+copy of this software and associated documentation files (the “Software”), 
+to deal in the Software without restriction, including without limitation 
+the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the 
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in 
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR 
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "mongodb-queue",
+  "name": "fh-mongodb-queue",
   "version": "2.2.0",
-  "description": "Message queues which uses MongoDB.",
+  "description": "Message queues which uses MongoDB. Fork of https://github.com/chilts/mongodb-queue",
   "main": "mongodb-queue.js",
   "scripts": {
     "test": "set -e; for FILE in test/*.js; do node $FILE; done"
@@ -12,14 +12,13 @@
     "mongodb": "^2.0.48",
     "async": "^1.5.0"
   },
-  "homepage": "https://github.com/chilts/mongodb-queue",
+  "homepage": "https://github.com/feedhenry/fh-mongodb-queue",
   "repository": {
     "type": "git",
-    "url": "git://github.com/chilts/mongodb-queue.git"
+    "url": "git://github.com/feedhenry/fh-mongodb-queue.git"
   },
   "bugs": {
-    "url": "http://github.com/chilts/mongodb-queue/issues",
-    "mail": "andychilton@gmail.com"
+    "url": "https://issues.jboss.org/projects/FH/issues"
   },
   "author": {
     "name": "Andrew Chilton",


### PR DESCRIPTION
## Jira link
https://issues.jboss.org/browse/RHMAP-19582

### What
Prepare repo to publish on npm

## Why
fh-mongodb-queue functionality is needed by platform components, but original upstream (mongodb-queue) is awaiting changes to be merged, and a current version of the lib to be published to npm. Thus, mongodb-queue has been forked, renamed, and will be published to npm as fh-mongodb-queue to overcome this issue.

## How
Add/ update files as necessary so lib can be published to npm

## Verification steps
PR can be verified against the required internal process for publishing new npm modules [here](https://github.com/fheng/help/blob/6a12a8cd799603c7879b16204317b3279f3f5bee/developer_guides/engineering_wiki/Publishing-NPM-modules.md) (link only available to logged in Red Hat Mobile users)